### PR TITLE
Security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Every change, update, bug fix or new feature will be documented in this file as 
 
 <a name="Unreleased"></a>
 
+### 0.3.2
+
+*   SSL Connections
+    *   Force the use of HTTPS to load the HERE Maps scripts if the "secure" flag on the HEREMap instance is set to true.
+
+### 0.3.1
+
+*   Type Definitions
+    *   Source the type definitions for this project from DefinitelyTyped instead of directly bundling the files.
+
 ### 0.3.0
 
 *   Circle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-here-maps",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React.js HERE Maps component",
   "main": "dist/main.js",
   "scripts": {

--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -130,7 +130,11 @@ implements React.ChildContextProvider<HEREMapChildContext> {
     }
 
     public componentWillMount() {
-        cache(getScriptMap());
+        const {
+            secure,
+        } = this.props;
+
+        cache(getScriptMap(secure === true));
         const stylesheetUrl = "//js.api.here.com/v3/3.0/mapsjs-ui.css";
         getLink(stylesheetUrl, "HERE Maps UI");
     }

--- a/src/utils/get-script-map.ts
+++ b/src/utils/get-script-map.ts
@@ -10,7 +10,7 @@ export function getScriptMap(secure?: boolean): ScriptMap {
     const codeVersion = "3.0";
 
     // get the relevant protocol for the HERE Maps API
-    let protocol = null;
+    let protocol = "";
 
     if (secure === true) {
         protocol = "https:";

--- a/src/utils/get-script-map.ts
+++ b/src/utils/get-script-map.ts
@@ -4,13 +4,20 @@ interface ScriptMap {
     [key: string]: string;
 }
 
-export function getScriptMap(): ScriptMap {
+export function getScriptMap(secure?: boolean): ScriptMap {
     // store the versions of the HERE API
     const apiVersion = "v3";
     const codeVersion = "3.0";
 
+    // get the relevant protocol for the HERE Maps API
+    let protocol = null;
+
+    if (secure === true) {
+        protocol = "https:";
+    }
+
     // the base url for all scripts from the API
-    const baseUrl: string = `//js.api.here.com/` +
+    const baseUrl: string = `${protocol}//js.api.here.com/` +
         `${apiVersion}/${codeVersion}`;
 
     // core code


### PR DESCRIPTION
This bumps the release to 0.3.2, and brings with it the following changes:
-   SSL Connections
  -   Force the use of HTTPS to load the HERE Maps scripts if the "secure" flag on the HEREMap instance is set to true.
