### PR TITLE
[14] use namespaced polyfills

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,6 @@
 // import from npm
 import Promise = require("bluebird");
-import "core-js";
+import * as Map from "core-js/library/fn/map";
 import { assignIn, forEach } from "lodash";
 
 // declare an interface for the object that is

--- a/src/utils/get-dom-marker-icon.ts
+++ b/src/utils/get-dom-marker-icon.ts
@@ -1,4 +1,4 @@
-import "core-js";
+import * as Map from "core-js/library/fn/map";
 
 /**
  * Map for HTML strings against H.map.DomIcon instances

--- a/src/utils/get-link.ts
+++ b/src/utils/get-link.ts
@@ -1,5 +1,5 @@
 // import from npm
-import "core-js";
+import * as Map from "core-js/library/fn/map";
 import { assignIn } from "lodash";
 
 // declare an interface for the object that is

--- a/src/utils/get-marker-icon.ts
+++ b/src/utils/get-marker-icon.ts
@@ -1,4 +1,4 @@
-import "core-js";
+import * as Map from "core-js/library/fn/map";
 
 /**
  * Map for image URL strings against H.map.Icon instances

--- a/src/utils/mixin.ts
+++ b/src/utils/mixin.ts
@@ -1,4 +1,5 @@
-import "core-js";
+import * as Reflect from "core-js/library/fn/reflect";
+import * as Symbol from "core-js/library/fn/symbol";
 
 export function mixin(behaviour: any, sharedBehaviour: any = {}) {
   // these keys reflect the behaviour that is to be attached to class instances


### PR DESCRIPTION
This has two effects:
1) lower webpacked size: since we are being more selective on what to import, bundled file size should be smaller.
2) the polyfills will not be put into global namespace, preventing possible issues with other libraries or polyfills.